### PR TITLE
ConvivaMetadata: Update type to handle custom tags with numbers

### DIFF
--- a/conviva-core-sdk.d.ts
+++ b/conviva-core-sdk.d.ts
@@ -174,7 +174,10 @@ export interface ConvivaAdListenerInfo {
     [ConvivaKeys.IMASDK_CONTENT_PLAYER]: object;
 }
 
-export type ConvivaMetadata = {
+export type ConvivaMetadata = { 
+    // Custom tags 
+    [key: string]: string | number 
+} & { 
     [ConvivaKeys.IS_LIVE]?:
         | ConvivaConstants['StreamType']['LIVE']
         | ConvivaConstants['StreamType']['UNKNOWN']
@@ -186,7 +189,7 @@ export type ConvivaMetadata = {
     [ConvivaKeys.ENCODED_FRAMERATE]?: number | null;
     [ConvivaKeys.VIEWER_ID]?: string | null;
     [ConvivaKeys.DEFAULT_RESOURCE]?: string | null;
-} & { [key: string]: string | number }; // Custom tags
+}
 
 export interface VideoAnalytics {
     configureExistingSession(sessionKey: string): void;

--- a/conviva-core-sdk.d.ts
+++ b/conviva-core-sdk.d.ts
@@ -186,7 +186,7 @@ export type ConvivaMetadata = {
     [ConvivaKeys.ENCODED_FRAMERATE]?: number | null;
     [ConvivaKeys.VIEWER_ID]?: string | null;
     [ConvivaKeys.DEFAULT_RESOURCE]?: string | null;
-} & { [key: string]: string }; // Custom tags
+} & { [key: string]: string | number }; // Custom tags
 
 export interface VideoAnalytics {
     configureExistingSession(sessionKey: string): void;


### PR DESCRIPTION
When you were trying to set eg. ENCODED_FRAMERATE, the type would clash with the custom tags type and you would get an error whether you put a string or a number.